### PR TITLE
Get current timestamp instead of requestAnimationFrame callback argument

### DIFF
--- a/lime/_backend/html5/HTML5Application.hx
+++ b/lime/_backend/html5/HTML5Application.hx
@@ -375,10 +375,12 @@ class HTML5Application {
 
 	private static function staticHandleApplicationEvent(timestamp:Float)
 	{
+		var correctedTimestamp:Float = untyped __js__ ('performance.now()');
+
 		#if (dev && js)
-		instance.handleApplicationEvent(timestamp * untyped $global.Tools.speedFactor);
+		instance.handleApplicationEvent(correctedTimestamp * untyped $global.Tools.speedFactor);
 		#else
-		instance.handleApplicationEvent(timestamp);
+		instance.handleApplicationEvent(correctedTimestamp);
 		#end
 	}
 


### PR DESCRIPTION
From: https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame

> The callback method is passed a single argument, a DOMHighResTimeStamp, which indicates the current time when callbacks queued by requestAnimationFrame begin to fire. Multiple callbacks in a single frame, therefore, each receive the same timestamp even though time has passed during the computation of every previous callback's workload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/lime/37)
<!-- Reviewable:end -->
